### PR TITLE
Add support to be able to read headers from enhanced DICOMs 

### DIFF
--- a/python/lib/import_dicom_study/dicom_database.py
+++ b/python/lib/import_dicom_study/dicom_database.py
@@ -101,7 +101,6 @@ def insert_files_series(db: Database, dicom_archive: DbDicomArchive, dicom_summa
     """
 
     for acquisition in dicom_summary.acquisitions:
-        print(acquisition)
         db.add(DbDicomArchiveSeries(
             archive_id         = dicom_archive.id,
             series_number      = acquisition.series_number,
@@ -128,7 +127,6 @@ def insert_files_series(db: Database, dicom_archive: DbDicomArchive, dicom_summa
             dicom_file.echo_time,
             dicom_file.sequence_name,
         )
-        print(dicom_series)
 
         db.add(DbDicomArchiveFile(
             archive_id         = dicom_archive.id,

--- a/python/lib/import_dicom_study/dicom_database.py
+++ b/python/lib/import_dicom_study/dicom_database.py
@@ -101,6 +101,7 @@ def insert_files_series(db: Database, dicom_archive: DbDicomArchive, dicom_summa
     """
 
     for acquisition in dicom_summary.acquisitions:
+        print(acquisition)
         db.add(DbDicomArchiveSeries(
             archive_id         = dicom_archive.id,
             series_number      = acquisition.series_number,
@@ -119,6 +120,7 @@ def insert_files_series(db: Database, dicom_archive: DbDicomArchive, dicom_summa
     db.commit()
 
     for dicom_file in dicom_summary.dicom_files:
+
         dicom_series = get_dicom_archive_series_with_file_info(
             db,
             dicom_file.series_uid or '',
@@ -126,6 +128,7 @@ def insert_files_series(db: Database, dicom_archive: DbDicomArchive, dicom_summa
             dicom_file.echo_time,
             dicom_file.sequence_name,
         )
+        print(dicom_series)
 
         db.add(DbDicomArchiveFile(
             archive_id         = dicom_archive.id,

--- a/python/lib/import_dicom_study/dicom_database.py
+++ b/python/lib/import_dicom_study/dicom_database.py
@@ -119,7 +119,6 @@ def insert_files_series(db: Database, dicom_archive: DbDicomArchive, dicom_summa
     db.commit()
 
     for dicom_file in dicom_summary.dicom_files:
-
         dicom_series = get_dicom_archive_series_with_file_info(
             db,
             dicom_file.series_uid or '',

--- a/python/lib/import_dicom_study/summary_get.py
+++ b/python/lib/import_dicom_study/summary_get.py
@@ -73,6 +73,8 @@ def get_dicom_study_summary(dicom_study_dir_path: str, verbose: bool):
     dicom_files.sort(key=cmp_to_key(compare_dicom_files))
     acquisitions.sort(key=cmp_to_key(compare_acquisitions))
 
+    print(dicom_files)
+
     return DicomStudySummary(study_info, acquisitions, dicom_files, other_files)
 
 

--- a/python/lib/import_dicom_study/summary_get.py
+++ b/python/lib/import_dicom_study/summary_get.py
@@ -51,6 +51,7 @@ def get_dicom_study_summary(dicom_study_dir_path: str, verbose: bool):
                 raise pydicom.errors.InvalidDicomError
 
             dicom_files.append(get_dicom_file_info(dicom))
+            print(get_dicom_file_info(dicom))
 
             acquisition_key = DicomStudyAcquisitionKey(
                 series_number = dicom.SeriesNumber,
@@ -72,8 +73,6 @@ def get_dicom_study_summary(dicom_study_dir_path: str, verbose: bool):
 
     dicom_files.sort(key=cmp_to_key(compare_dicom_files))
     acquisitions.sort(key=cmp_to_key(compare_acquisitions))
-
-    print(dicom_files)
 
     return DicomStudySummary(study_info, acquisitions, dicom_files, other_files)
 

--- a/python/lib/import_dicom_study/summary_get.py
+++ b/python/lib/import_dicom_study/summary_get.py
@@ -38,7 +38,7 @@ def get_dicom_study_summary(dicom_study_dir_path: str, verbose: bool):
 
         try:
             dicom = pydicom.dcmread(file_path)  # type: ignore
-            print(dicom)
+
             if study_info is None:
                 study_info = get_dicom_study_info(dicom)
 
@@ -52,7 +52,6 @@ def get_dicom_study_summary(dicom_study_dir_path: str, verbose: bool):
                 raise pydicom.errors.InvalidDicomError
 
             dicom_files.append(get_dicom_file_info(dicom))
-            print(get_dicom_file_info(dicom))
 
             acquisition_key = DicomStudyAcquisitionKey(
                 series_number = dicom.SeriesNumber,
@@ -180,6 +179,10 @@ def read_value_none(dicom: pydicom.Dataset, tag: str):
     """
 
     if tag not in dicom:
+        for elem in dicom.iterall():
+            # to find header information in enhanced DICOMs, need to look into subheaders
+            if elem.tag == tag:
+                return elem.value
         return None
 
     return dicom[tag].value or None

--- a/python/lib/import_dicom_study/summary_get.py
+++ b/python/lib/import_dicom_study/summary_get.py
@@ -38,6 +38,7 @@ def get_dicom_study_summary(dicom_study_dir_path: str, verbose: bool):
 
         try:
             dicom = pydicom.dcmread(file_path)  # type: ignore
+            print(dicom)
             if study_info is None:
                 study_info = get_dicom_study_info(dicom)
 

--- a/python/lib/import_dicom_study/summary_get.py
+++ b/python/lib/import_dicom_study/summary_get.py
@@ -38,7 +38,6 @@ def get_dicom_study_summary(dicom_study_dir_path: str, verbose: bool):
 
         try:
             dicom = pydicom.dcmread(file_path)  # type: ignore
-
             if study_info is None:
                 study_info = get_dicom_study_info(dicom)
 


### PR DESCRIPTION
In enhanced DICOMs, headers are embedded inside other headers. This change will allow to fetch header information from enhanced DICOMs if it could not be found using the standard DICOM approach.